### PR TITLE
Update pip update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Update pip
         run: |
-          pip install --upgrade pip
+          python -m pip install --upgrade pip
 
       - name: Cache pip dependencies
         uses: actions/cache@v5


### PR DESCRIPTION
## Issue

The windows CI has issues with updating pip. The command changed.

```

Run pip install --upgrade pip
Requirement already satisfied: pip in c:\hostedtoolcache\windows\python\3.10.11\x64\lib\site-packages (25.3)
Collecting pip
  Downloading pip-26.0-py3-none-any.whl.metadata (4.7 kB)
Downloading pip-26.0-py3-none-any.whl (1.8 MB)
   ---------------------------------------- 1.8/1.8 MB 32.5 MB/s  0:00:00

Notice:  A new release of pip is available: 25.3 -> 26.0
Notice:  To update, run: python.exe -m pip install --upgrade pip
ERROR: To modify pip, please run the following command:
C:\hostedtoolcache\windows\Python\3.10.11\x64\python.exe -m pip install --upgrade pip
```

## Changes

Use recommended way to update pip.