### PR TITLE
Updated GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,9 @@ updates:
     schedule:
       interval: monthly
     groups:
-      actions-minor:
+      actions:
         update-types:
+          - major
           - minor
           - patch
 

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -58,7 +58,7 @@ jobs:
       - if: ${{ failure() && steps.diff.outcome == 'failure' }}
         name: Upload Artifact
         id: upload
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Get HTML artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: html-artifacts/
           pattern: '*.html'


### PR DESCRIPTION
## Changes

* Group dependabot PRs for GitHub actions
* actions/upload-artifact: v6 --> v7
* actions/download-artifact: v7 --> v8